### PR TITLE
Added support to WashTower

### DIFF
--- a/apps/ThinQ_Integration.groovy
+++ b/apps/ThinQ_Integration.groovy
@@ -45,6 +45,8 @@ preferences {
 	201, // Washer
 	202, // Dryer
 	204, // Dishwasher
+    221, // WashTower - Washer
+    222, // WashTower - Dryer
 	301 // Oven
 ]
 
@@ -52,6 +54,8 @@ preferences {
 	Fridge: 101,
 	Washer: 201,
 	Dryer: 202,
+	WashTowerWasher: 221,
+	WashTowerDryer: 222,
 	Dishwasher: 204,
 	Oven: 301
 ]
@@ -316,9 +320,11 @@ def initialize() {
 		def driverName = ""
 		switch (deviceDetails.type) {
 			case deviceTypeConstants.Dryer:
+            case deviceTypeConstants.WashTowerDryer:
 				driverName = "LG ThinQ Dryer"
 				break
 			case deviceTypeConstants.Washer:
+            case deviceTypeConstants.WashTowerWasher:
 				driverName = "LG ThinQ Washer"
 				break
 			case deviceTypeConstants.Fridge:
@@ -335,7 +341,7 @@ def initialize() {
 			hasV1Device = deviceDetails.version == "thinq1"
 		def childDevice = getChildDevice("thinq:"+deviceDetails.id)
 		if (childDevice == null) {
-			childDevice = addChildDevice("dcm.thinq", driverName, "thinq:" + deviceDetails.id, 1234, ["name": deviceDetails.name,isComponent: false])
+			childDevice = addChildDevice("dcm.thinq", driverName, "thinq:" + deviceDetails.id, 1234, ["name": driverName, isComponent: false])
 			if (!findMasterDevice() && deviceDetails.version == "thinq2") {
 				childDevice.updateDataValue("master", "true")
 				childDevice.initialize()
@@ -780,6 +786,10 @@ def getDevices() {
 	if (data) {
 		def devices = data.item
 		logger("info", "Found ${devices?.size()} devices")
+	
+        devices.each {
+            logger("info", "modelJsonUri: ${it.modelJsonUri}, id: ${it.deviceId}, name: ${it.alias}, type: ${it.deviceType}, version: ${it.platformType}, supported: ${supportedDeviceTypes.contains(it.deviceType) ? "True" : " False"}")
+	    }
 
 		return devices.findAll { d -> supportedDeviceTypes.find { supported -> supported == d.deviceType } }
 	}

--- a/apps/ThinQ_Integration.groovy
+++ b/apps/ThinQ_Integration.groovy
@@ -341,7 +341,7 @@ def initialize() {
 			hasV1Device = deviceDetails.version == "thinq1"
 		def childDevice = getChildDevice("thinq:"+deviceDetails.id)
 		if (childDevice == null) {
-			childDevice = addChildDevice("dcm.thinq", driverName, "thinq:" + deviceDetails.id, 1234, ["name": driverName, isComponent: false])
+			childDevice = addChildDevice("dcm.thinq", driverName, "thinq:" + deviceDetails.id, 1234, ["name": deviceDetails.name, isComponent: false])
 			if (!findMasterDevice() && deviceDetails.version == "thinq2") {
 				childDevice.updateDataValue("master", "true")
 				childDevice.initialize()

--- a/packageManifest.json
+++ b/packageManifest.json
@@ -2,8 +2,9 @@
   "packageName": "LG ThinQ Integration",
   "author": "Dominick Meglio",
   "minimumHEVersion": "2.1.9",
-  "version": "1.0.0",
-  "dateReleased": "2021-06-18",
+  "version": "1.1.0",
+  "dateReleased": "2021-07-06",
+  "releaseNotes": "Added support for Wash Tower devices courtesy of rfg81!",
   "communityLink": "https://community.hubitat.com/t/my-god-anyone-attempted-an-lg-thinq-integration/51925",
   "apps": [
     {


### PR DESCRIPTION
Added support to WashTower (Washer and Dryer in one stack device). Using the device name as the driver name to fix issue were the WashTower - Washer has the alias "Washer" but the WashTower - Dryer has the 'wrong' alias "WashTower". Improved debug to show if a device is supported by the app.